### PR TITLE
Skip test_instability_around_zero on windows

### DIFF
--- a/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
+++ b/tests/cupyx_tests/scipy_tests/stats_tests/test_morestats.py
@@ -1,4 +1,7 @@
+import sys
+
 import numpy
+import pytest
 import scipy.stats
 
 import cupy
@@ -142,6 +145,9 @@ class TestBoxcox_llf:
         else:
             return result
 
+    @pytest.mark.skipif(
+        not sys.platform.startswith('linux'),
+        reason="Return value of scipy.stats.boxcox_llf has large error")
     @testing.with_requires('scipy>=1.13')
     @testing.numpy_cupy_allclose(scipy_name='scp', atol=atol, rtol=rtol)
     def test_instability_around_zero(self, xp, scp):


### PR DESCRIPTION
The return value of `scipy.stats.boxcox_llf` seems to have large numerical error on Windows.